### PR TITLE
Fixed bug where script was not created and submitted if an absolute output path was given

### DIFF
--- a/submit_vibfold.py
+++ b/submit_vibfold.py
@@ -49,12 +49,12 @@ def submit(FASTA_FILE, IS_COMPLEX, MSA_MODE, SAVE_DIR, DO_RELAX, USE_TEMPLATES, 
     if not SAVE_DIR.startswith('/'):
         SAVE_DIR = f'$PBS_O_WORKDIR/{SAVE_DIR}'
 
-        for prot_id, seq in all_seqs.items():
-            script_content = f'''#!/bin/bash
-#PBS -N VIBFold_{prot_id}
-#PBS -l nodes=1:ppn={12 if cluster=='accelgor' else 8},gpus=1
-#PBS -l mem={125 if cluster=='accelgor' else 64}g
-#PBS -l walltime=48:00:00
+    for prot_id, seq in all_seqs.items():
+        script_content = f'''#!/bin/bash
+#PBS-N VIBFold_{prot_id}
+#PBS-l nodes=1:ppn={12 if cluster=='accelgor' else 8},gpus=1
+#PBS-l mem={125 if cluster=='accelgor' else 64}g
+#PBS-l walltime=48:00:00
 
 module load Python/3.10.4-GCCcore-11.3.0
 
@@ -81,17 +81,17 @@ python VIBFold.py \
  --max_recycles {MAX_RECYCLES}
 '''
 
-            scriptname = 'submit_new.sh'
-            f = open(scriptname,'w')
-            print(script_content,file=f)
-            f.close()
+        scriptname = 'submit_new.sh'
+        f = open(scriptname,'w')
+        print(script_content,file=f)
+        f.close()
 
-            print()
-            print(f'############# submitting {prot_id} #############')
-            subprocess.Popen(['echo',f'{prot_id}'],shell=False)
-            subprocess.Popen(['qsub',f'{scriptname}'],shell=False).wait()
-            subprocess.Popen(['rm',f'{scriptname}'],shell=False).wait()
-            print()
+        print()
+        print(f'############# submitting {prot_id} #############')
+        subprocess.Popen(['echo',f'{prot_id}'],shell=False)
+        subprocess.Popen(['qsub',f'{scriptname}'],shell=False).wait()
+        subprocess.Popen(['rm',f'{scriptname}'],shell=False).wait()
+        print()
 
 if __name__ == "__main__":
     submit(FASTA_FILE, IS_COMPLEX, MSA_MODE, SAVE_DIR, DO_RELAX, USE_TEMPLATES, MAX_RECYCLES)

--- a/submit_vibfold.py
+++ b/submit_vibfold.py
@@ -10,6 +10,7 @@ MAX_RECYCLES = 3                        # default == 3
 
 import subprocess
 import os
+import sys
 
 def submit(FASTA_FILE, IS_COMPLEX, MSA_MODE, SAVE_DIR, DO_RELAX, USE_TEMPLATES, MAX_RECYCLES):
     assert ' ' not in FASTA_FILE, 'The name of your FASTA file cannot contain any spaces'
@@ -19,6 +20,17 @@ def submit(FASTA_FILE, IS_COMPLEX, MSA_MODE, SAVE_DIR, DO_RELAX, USE_TEMPLATES, 
               'joltik' if 'joltik' in module_info else ''
     if not cluster:
         raise NotImplementedError('Cluster joltik/accelgor not found in "ml" output. Did you use "module swap cluster/joltik" (or other)?')
+
+    if not os.path.exists(FASTA_FILE):
+        sys.exit(f"FASTA_FILE '{FASTA_FILE}' not found")
+
+    msa_modes = ['alphafold_default', 'mmseqs2_server']
+    if MSA_MODE not in msa_modes:
+        sys.exit(f"Only 'alphafold_default' or 'mmseqs2_server' allowed as MSA_MODE, got '{MSA_MODE}'")
+
+    relax = ['all', 'best', 'none']
+    if DO_RELAX not in relax:
+        sys.exit(f"Only 'all', 'best' or 'none' allowed for DO_RELAX, got '{DO_RELAX}'")
 
     fasta_d = {}
     seq = ''
@@ -95,3 +107,4 @@ python VIBFold.py \
 
 if __name__ == "__main__":
     submit(FASTA_FILE, IS_COMPLEX, MSA_MODE, SAVE_DIR, DO_RELAX, USE_TEMPLATES, MAX_RECYCLES)
+    sys.exit(0)


### PR DESCRIPTION
The part that created the script content and submitted this script was indented in a wrong way such that this would never happen if an absolute output path was provided by the user.

Also added some more informative error messages in case of wrong user defined input to prevent silent exit of the script.